### PR TITLE
fixed hyphen on lambda names

### DIFF
--- a/naming.js
+++ b/naming.js
@@ -35,7 +35,7 @@ module.exports = {
         name = name
             .replace(this.provider.getStage() || 'dev', '')
             .replace(this.provider.serverless.service.service, '')
-            .replace(/\-/g, '')
+            .replace(/^\-+/g, '')
             .trim()
         var logGroupName = this._getMappings(name).logGroup
         return logGroupName


### PR DESCRIPTION
@emilhdiaz 
The global removal of hyphen removes the hyphen on the lambda names as well. I fixed this by adding a prefix modifier and it only removes the unnecessary dashes in front of the lambda name and not inside the lambda name.

Can you accept this PR?

Thanks  